### PR TITLE
Get Loop Unrolling Example Working out of Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # CompilerGymExamples
-Example environments and scripts utilizing CompilerGym
+Example environments and scripts utilizing CompilerGym without having to build it.
+
+# Steps
+1. `pip install compiler_gym`
+2. `python example_unrolling_service/example_without_bazel.py`

--- a/benchmarks/conv2d.c
+++ b/benchmarks/conv2d.c
@@ -1,0 +1,76 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#include "header.h"
+
+// TODO: use templates instead of macros
+#ifndef N
+#define N 32
+#endif
+
+#ifndef Ih
+#define Ih 3
+#endif
+
+#ifndef Iw
+#define Iw 12
+#endif
+
+#ifndef Ic
+#define Ic 12
+#endif
+
+#ifndef Oc
+#define Oc 64
+#endif
+
+#ifndef Kh
+#define Kh 3
+#endif
+
+#ifndef Kw
+#define Kw 3
+#endif
+
+// TODO: include pad, stride, and dilation
+
+#define Oh Ih - Kh + 1
+#define Ow Iw - Kw + 1
+
+float x[N][Ih][Iw][Ic];
+float w[Oc][Kh][Kw][Ic];
+float y[N][Oh][Ow][Oc];
+
+__attribute__((noinline))
+//template <N=32, Iw=...>
+void conv2d(int* ret) {
+  // loop over output
+  for (int n = 0; n < N; n++) {
+    for (int oh = 0; oh < Oh; oh++) {
+      for (int ow = 0; ow < Ow; ow++) {
+        for (int oc = 0; oc < Oc; oc++) {
+          y[n][oh][ow][oc] = 0;
+          // loop over filter
+          for (int kh = 0; kh < Kh; kh++) {
+            for (int kw = 0; kw < Kw; kw++) {
+              for (int ic = 0; ic < Iw; ic++) {
+                // TODO: include pad, stride, and dilation
+                y[n][oh][ow][oc] += w[oc][kh][kw][ic] * x[n][oh - kh + 1][ow - kw + 1][ic];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  *ret = y[N - 1][Oh - 1][Ow - 1][Oc - 1];
+}
+
+__attribute__((optnone)) int main(int argc, char* argv[]) {
+  int dummy = 0;
+  // TODO: initialize tensors
+  BENCH("conv2d", conv2d(&dummy), 100, dummy);
+
+  return 0;
+}

--- a/benchmarks/offsets1.c
+++ b/benchmarks/offsets1.c
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+#include "header.h"
+
+#ifndef N
+#define N 1000000
+#endif
+
+#ifndef n
+#define n 3
+#endif
+
+int A[N];
+
+__attribute__((noinline)) void example1(int* ret) {
+  //#pragma unroll(n)
+  for (int i = 0; i < N - 3; i++) A[i] = A[i + 1] + A[i + 2] + A[i + 3];
+
+  *ret = A[N - 1];
+}
+
+__attribute__((optnone)) int main(int argc, char* argv[]) {
+  int dummy = 0;
+  // TODO: initialize tensors
+  BENCH("example1", example1(&dummy), 100, dummy);
+
+  return 0;
+}

--- a/example_unrolling_service/example_without_bazel.py
+++ b/example_unrolling_service/example_without_bazel.py
@@ -138,26 +138,15 @@ class UnrollingDataset(Dataset):
         )
 
     def benchmark_uris(self) -> Iterable[str]:
+        # FIXME: yield from (f"benchmark://unrolling-v0{k}" for k in self._benchmarks.keys())
         yield from self._benchmarks.keys()
 
     def benchmark(self, uri: str) -> Benchmark:
         if uri in self._benchmarks:
+            # FIXME: return self._benchmarks[uri.path]
             return self._benchmarks[uri]
         else:
             raise LookupError("Unknown program name")
-
-
-# TODO: replace after pip sync with GitHub
-'''
-    def benchmark_uris(self) -> Iterable[str]:
-        yield from (f"benchmark://unrolling-v0{k}" for k in self._benchmarks.keys())
-
-    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
-        if uri.path in self._benchmarks:
-            return self._benchmarks[uri.path]
-        else:
-            raise LookupError("Unknown program name")
-'''
 
 
 # Register the unrolling example service on module import. After importing this module,

--- a/example_unrolling_service/example_without_bazel.py
+++ b/example_unrolling_service/example_without_bazel.py
@@ -98,18 +98,8 @@ class UnrollingDataset(Dataset):
         )
 
         self._benchmarks = {
-            "benchmark://unrolling-v0/offsets1": Benchmark.from_file_contents(  # FIXME: "/offsets1": Benchmark.from_file_contents(
-                "benchmark://unrolling-v0/offsets1",
-                # FIXME: self.preprocess(BENCHMARKS_PATH / "offsets1.c"),
-                self.preprocess(os.path.join(
-                    BENCHMARKS_PATH, "offsets1.c")),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
-            ),
-            "benchmark://unrolling-v0/conv2d": Benchmark.from_file_contents(  # FIXME: "/conv2d": Benchmark.from_file_contents(
-                "benchmark://unrolling-v0/conv2d",
-                # FIXME: self.preprocess(BENCHMARKS_PATH / "conv2d.c"),
-                self.preprocess(os.path.join(
-                    BENCHMARKS_PATH, "conv2d.c")),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
-            ),
+            "/offsets1": Benchmark.from_file_contents(self.preprocess(BENCHMARKS_PATH / "offsets1.c"), "Ir data".encode("utf-8")),
+            "/conv2d": Benchmark.from_file_contents(self.preprocess(BENCHMARKS_PATH / "conv2d.c"), "Ir data".encode("utf-8")),
         }
 
     @staticmethod

--- a/example_unrolling_service/example_without_bazel.py
+++ b/example_unrolling_service/example_without_bazel.py
@@ -18,6 +18,7 @@ from typing import Iterable
 
 import compiler_gym
 from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
 from compiler_gym.envs.llvm.llvm_benchmark import get_system_includes
 from compiler_gym.spaces import Reward
 from compiler_gym.third_party import llvm
@@ -118,7 +119,7 @@ class UnrollingDataset(Dataset):
         # this pre-processing, or do it on the service side, once support for
         # multi-file benchmarks lands.
         cmd = [
-            "clang",  # str(llvm.clang_path()), # FIXME
+            str(llvm.clang_path()),
             "-E",
             "-o",
             "-",
@@ -134,14 +135,14 @@ class UnrollingDataset(Dataset):
             timeout=300,
         )
 
-    def benchmark_uris(self) -> Iterable[str]:
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Iterable[str]:
         # FIXME: yield from (f"benchmark://unrolling-v0{k}" for k in self._benchmarks.keys())
         yield from self._benchmarks.keys()
 
     def benchmark(self, uri: str) -> Benchmark:
         if uri in self._benchmarks:
             # FIXME: return self._benchmarks[uri.path]
-            return self._benchmarks[uri]
+            return self._benchmarks[uri.path]
         else:
             raise LookupError("Unknown program name")
 

--- a/example_unrolling_service/example_without_bazel.py
+++ b/example_unrolling_service/example_without_bazel.py
@@ -1,0 +1,204 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""This script demonstrates how the Python example service without needing
+to use the bazel build system.
+
+Prerequisite:
+    # In the repo's INSTALL.md, follow the 'Building from source using CMake' instructions with `-DCOMPILER_GYM_BUILD_EXAMPLES=ON` added to the `cmake` command
+    $ cd <path to source directory>/examples
+Usage:
+
+    $ python example_unrolling_service/examples_without_bazel.py
+
+It is equivalent in behavior to the example.py script in this directory.
+"""
+import subprocess
+from pathlib import Path
+from typing import Iterable
+import os  # FIXME
+
+import compiler_gym
+from compiler_gym.datasets import Benchmark, Dataset
+from compiler_gym.datasets.uri import BenchmarkUri
+# from compiler_gym.envs.llvm.llvm_benchmark import get_system_library_flags #FIXME
+from compiler_gym.spaces import Reward
+from compiler_gym.third_party import llvm
+from compiler_gym.util.registration import register
+from compiler_gym.util.commands import run_command
+
+
+UNROLLING_PY_SERVICE_BINARY: Path = Path(
+    "example_unrolling_service/service_py/example_service.py"
+)
+assert UNROLLING_PY_SERVICE_BINARY.is_file(), "Service script not found"
+
+BENCHMARKS_PATH: Path = Path("benchmarks")
+
+NEURO_VECTORIZER_HEADER: Path = Path(
+    "third_party/neuro-vectorizer/header.h"
+)
+
+
+class RuntimeReward(Reward):
+    """An example reward that uses changes in the "runtime" observation value
+    to compute incremental reward.
+    """
+
+    def __init__(self):
+        super().__init__(
+            id="runtime",  # name="runtime", #FIXME
+            observation_spaces=["runtime"],
+            default_value=0,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.baseline_runtime = 0
+
+    def reset(self, benchmark: str, observation_view):
+        del benchmark  # unused
+        self.baseline_runtime = observation_view["runtime"]
+
+    def update(self, action, observations, observation_view):
+        del action  # unused
+        del observation_view  # unused
+        return float(self.baseline_runtime - observations[0]) / self.baseline_runtime
+
+
+class SizeReward(Reward):
+    """An example reward that uses changes in the "size" observation value
+    to compute incremental reward.
+    """
+
+    def __init__(self):
+        super().__init__(
+            id="size",  # name="size", #FIXME
+            observation_spaces=["size"],
+            default_value=0,
+            default_negates_returns=True,
+            deterministic=False,
+            platform_dependent=True,
+        )
+        self.baseline_size = 0
+
+    def reset(self, benchmark: str, observation_view):
+        del benchmark  # unused
+        self.baseline_runtime = observation_view["size"]
+
+    def update(self, action, observations, observation_view):
+        del action  # unused
+        del observation_view  # unused
+        return float(self.baseline_size - observations[0]) / self.baseline_size
+
+
+class UnrollingDataset(Dataset):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            name="benchmark://unrolling-v0",
+            license="MIT",
+            description="Unrolling example dataset",
+        )
+
+        self._benchmarks = {
+            "benchmark://unrolling-v0/offsets1": Benchmark.from_file_contents(  # FIXME: "/offsets1": Benchmark.from_file_contents(
+                "benchmark://unrolling-v0/offsets1",
+                # FIXME: self.preprocess(BENCHMARKS_PATH / "offsets1.c"),
+                bytes(self.preprocess(os.path.join(
+                    BENCHMARKS_PATH, "offsets1.c")), "utf8"),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
+            ),
+            "benchmark://unrolling-v0/conv2d": Benchmark.from_file_contents(  # FIXME: "/conv2d": Benchmark.from_file_contents(
+                "benchmark://unrolling-v0/conv2d",
+                # FIXME: self.preprocess(BENCHMARKS_PATH / "conv2d.c"),
+                bytes(self.preprocess(os.path.join(
+                    BENCHMARKS_PATH, "conv2d.c")), "utf8"),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
+            ),
+        }
+
+    @staticmethod
+    def preprocess(src: Path) -> bytes:
+        """Front a C source through the compiler frontend."""
+        # TODO(github.com/facebookresearch/CompilerGym/issues/325): We can skip
+        # this pre-processing, or do it on the service side, once support for
+        # multi-file benchmarks lands.
+        cmd = [
+            "clang",  # str(llvm.clang_path()), # FIXME
+            "-E",
+            "-o",
+            "-",
+            "-I",
+            str(NEURO_VECTORIZER_HEADER.parent),
+            str(src),
+        ]
+        # cmd += get_system_library_flags() # FIXME
+        return run_command(
+            cmd,
+            timeout=300,
+        )
+
+    def benchmark_uris(self) -> Iterable[str]:
+        yield from self._benchmarks.keys()
+
+    def benchmark(self, uri: str) -> Benchmark:
+        if uri in self._benchmarks:
+            return self._benchmarks[uri]
+        else:
+            raise LookupError("Unknown program name")
+
+
+# TODO: replace after pip sync with GitHub
+'''
+    def benchmark_uris(self) -> Iterable[str]:
+        yield from (f"benchmark://unrolling-v0{k}" for k in self._benchmarks.keys())
+
+    def benchmark_from_parsed_uri(self, uri: BenchmarkUri) -> Benchmark:
+        if uri.path in self._benchmarks:
+            return self._benchmarks[uri.path]
+        else:
+            raise LookupError("Unknown program name")
+'''
+
+
+# Register the unrolling example service on module import. After importing this module,
+# the unrolling-py-v0 environment will be available to gym.make(...).
+
+register(
+    id="unrolling-py-v0",
+    entry_point="compiler_gym.envs:CompilerEnv",
+    kwargs={
+        "service": UNROLLING_PY_SERVICE_BINARY,
+        "rewards": [RuntimeReward(), SizeReward()],
+        "datasets": [UnrollingDataset()],
+    },
+)
+
+with compiler_gym.make(
+    "unrolling-py-v0",
+    benchmark="unrolling-v0/offsets1",
+    observation_space="features",
+    reward_space="runtime",
+) as env:
+    compiler_gym.set_debug_level(4)  # TODO: check why this has no effect
+
+    observation = env.reset()
+    print("observation: ", observation)
+
+    print()
+
+    observation, reward, done, info = env.step(env.action_space.sample())
+    print("observation: ", observation)
+    print("reward: ", reward)
+    print("done: ", done)
+    print("info: ", info)
+
+    print()
+
+    observation, reward, done, info = env.step(env.action_space.sample())
+    print("observation: ", observation)
+    print("reward: ", reward)
+    print("done: ", done)
+    print("info: ", info)
+
+    # TODO: implement write_bitcode(..) or write_ir(..)
+    # env.write_bitcode("/tmp/output.bc")

--- a/example_unrolling_service/example_without_bazel.py
+++ b/example_unrolling_service/example_without_bazel.py
@@ -4,30 +4,25 @@
 # LICENSE file in the root directory of this source tree.
 """This script demonstrates how the Python example service without needing
 to use the bazel build system.
-
 Prerequisite:
     # In the repo's INSTALL.md, follow the 'Building from source using CMake' instructions with `-DCOMPILER_GYM_BUILD_EXAMPLES=ON` added to the `cmake` command
     $ cd <path to source directory>/examples
 Usage:
-
     $ python example_unrolling_service/examples_without_bazel.py
-
 It is equivalent in behavior to the example.py script in this directory.
 """
+import os
 import subprocess
 from pathlib import Path
 from typing import Iterable
-import os  # FIXME
 
 import compiler_gym
 from compiler_gym.datasets import Benchmark, Dataset
-from compiler_gym.datasets.uri import BenchmarkUri
-# from compiler_gym.envs.llvm.llvm_benchmark import get_system_library_flags #FIXME
+from compiler_gym.envs.llvm.llvm_benchmark import get_system_includes
 from compiler_gym.spaces import Reward
 from compiler_gym.third_party import llvm
 from compiler_gym.util.registration import register
 from compiler_gym.util.commands import run_command
-
 
 UNROLLING_PY_SERVICE_BINARY: Path = Path(
     "example_unrolling_service/service_py/example_service.py"
@@ -105,14 +100,14 @@ class UnrollingDataset(Dataset):
             "benchmark://unrolling-v0/offsets1": Benchmark.from_file_contents(  # FIXME: "/offsets1": Benchmark.from_file_contents(
                 "benchmark://unrolling-v0/offsets1",
                 # FIXME: self.preprocess(BENCHMARKS_PATH / "offsets1.c"),
-                bytes(self.preprocess(os.path.join(
-                    BENCHMARKS_PATH, "offsets1.c")), "utf8"),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
+                self.preprocess(os.path.join(
+                    BENCHMARKS_PATH, "offsets1.c")),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
             ),
             "benchmark://unrolling-v0/conv2d": Benchmark.from_file_contents(  # FIXME: "/conv2d": Benchmark.from_file_contents(
                 "benchmark://unrolling-v0/conv2d",
                 # FIXME: self.preprocess(BENCHMARKS_PATH / "conv2d.c"),
-                bytes(self.preprocess(os.path.join(
-                    BENCHMARKS_PATH, "conv2d.c")), "utf8"),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
+                self.preprocess(os.path.join(
+                    BENCHMARKS_PATH, "conv2d.c")),  # FIXME: why did we have to add "bytes(..., "utf8")" conversion
             ),
         }
 
@@ -132,7 +127,9 @@ class UnrollingDataset(Dataset):
             str(src),
         ]
         # cmd += get_system_library_flags() # FIXME
-        return run_command(
+        for directory in get_system_includes():
+            cmd += ["-isystem", str(directory)]
+        return subprocess.check_output(  # run_command(
             cmd,
             timeout=300,
         )

--- a/example_unrolling_service/service_py/example_service.py
+++ b/example_unrolling_service/service_py/example_service.py
@@ -1,0 +1,310 @@
+#! /usr/bin/env python3
+#
+#  Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""An example CompilerGym service in python."""
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import utils
+
+import compiler_gym.third_party.llvm as llvm
+from compiler_gym.service import CompilationSession
+from compiler_gym.service.proto import (
+    Action,
+    ActionSpace,
+    Benchmark,
+    ChoiceSpace,
+    NamedDiscreteSpace,
+    Observation,
+    ObservationSpace,
+    ScalarLimit,
+    ScalarRange,
+    ScalarRangeList,
+)
+from compiler_gym.service.runtime import create_and_run_compiler_gym_service
+from compiler_gym.util.commands import run_command
+
+
+class UnrollingCompilationSession(CompilationSession):
+    """Represents an instance of an interactive compilation session."""
+
+    compiler_version: str = "1.0.0"
+
+    # The list of actions that are supported by this service.
+    action_spaces = [
+        ActionSpace(
+            name="unrolling",
+            choice=[
+                ChoiceSpace(
+                    name="unroll_choice",
+                    named_discrete_space=NamedDiscreteSpace(
+                        value=[
+                            "-loop-unroll -unroll-count=2",
+                            "-loop-unroll -unroll-count=4",
+                            "-loop-unroll -unroll-count=8",
+                        ],
+                    ),
+                )
+            ],
+        )
+    ]
+
+    # A list of observation spaces supported by this service. Each of these
+    # ObservationSpace protos describes an observation space.
+    observation_spaces = [
+        ObservationSpace(
+            name="ir",
+            string_size_range=ScalarRange(min=ScalarLimit(value=0)),
+            deterministic=True,
+            platform_dependent=False,
+            default_value=Observation(string_value=""),
+        ),
+        ObservationSpace(
+            name="features",
+            int64_range_list=ScalarRangeList(
+                range=[
+                    ScalarRange(min=ScalarLimit(value=0),
+                                max=ScalarLimit(value=1e5)),
+                    ScalarRange(min=ScalarLimit(value=0),
+                                max=ScalarLimit(value=1e5)),
+                    ScalarRange(min=ScalarLimit(value=0),
+                                max=ScalarLimit(value=1e5)),
+                ]
+            ),
+        ),
+        ObservationSpace(
+            name="runtime",
+            scalar_double_range=ScalarRange(min=ScalarLimit(value=0)),
+            deterministic=False,
+            platform_dependent=True,
+            default_value=Observation(
+                scalar_double=0,
+            ),
+        ),
+        ObservationSpace(
+            name="size",
+            scalar_double_range=ScalarRange(min=ScalarLimit(value=0)),
+            deterministic=True,
+            platform_dependent=True,
+            default_value=Observation(
+                scalar_double=0,
+            ),
+        ),
+    ]
+
+    def __init__(
+        self,
+        working_directory: Path,
+        action_space: ActionSpace,
+        benchmark: Benchmark,
+        use_custom_opt: bool = True,
+    ):
+        super().__init__(working_directory, action_space, benchmark)
+        logging.info("Started a compilation session for %s", benchmark.uri)
+        self._benchmark = benchmark
+        self._action_space = action_space
+
+        # Resolve the paths to LLVM binaries once now.
+        self._clang = str(llvm.clang_path())
+        self._llc = str(llvm.llc_path())
+        self._llvm_diff = str(llvm.llvm_diff_path())
+        self._opt = str(llvm.opt_path())
+        # LLVM's opt does not always enforce the unrolling options passed as cli arguments. Hence, we created our own exeutable with custom unrolling pass in examples/example_unrolling_service/loop_unroller that enforces the unrolling factors passed in its cli.
+        # if self._use_custom_opt is true, use our custom exeutable, otherwise use LLVM's opt
+        self._use_custom_opt = use_custom_opt
+
+        # Dump the benchmark source to disk.
+        self._src_path = str(self.working_dir / "benchmark.c")
+        with open(self.working_dir / "benchmark.c", "wb") as f:
+            f.write(benchmark.program.contents)
+
+        self._llvm_path = str(self.working_dir / "benchmark.ll")
+        self._llvm_before_path = str(
+            self.working_dir / "benchmark.previous.ll")
+        self._obj_path = str(self.working_dir / "benchmark.o")
+        self._exe_path = str(self.working_dir / "benchmark.exe")
+
+        run_command(
+            [
+                self._clang,
+                "-Xclang",
+                "-disable-O0-optnone",
+                "-emit-llvm",
+                "-S",
+                self._src_path,
+                "-o",
+                self._llvm_path,
+            ],
+            timeout=30,
+        )
+
+    def apply_action(self, action: Action) -> Tuple[bool, Optional[ActionSpace], bool]:
+        num_choices = len(
+            self._action_space.choice[0].named_discrete_space.value)
+
+        if len(action.choice) != 1:
+            raise ValueError("Invalid choice count")
+
+        # This is the index into the action space's values ("a", "b", "c") that
+        # the user selected, e.g. 0 -> "a", 1 -> "b", 2 -> "c".
+        choice_index = action.choice[0].named_discrete_value_index
+        if choice_index < 0 or choice_index >= num_choices:
+            raise ValueError("Out-of-range")
+
+        args = self._action_space.choice[0].named_discrete_space.value[choice_index]
+        logging.info(
+            "Applying action %d, equivalent command-line arguments: '%s'",
+            choice_index,
+            args,
+        )
+        args = args.split()
+
+        # make a copy of the LLVM file to compare its contents after applying the action
+        shutil.copyfile(self._llvm_path, self._llvm_before_path)
+
+        # apply action
+        if self._use_custom_opt:
+            # our custom unroller has an additional `f` at the beginning of each argument
+            for i, arg in enumerate(args):
+                # convert -<argument> to -f<argument>
+                arg = arg[0] + "f" + arg[1:]
+                args[i] = arg
+            run_command(
+                [
+                    "../loop_unroller/loop_unroller",
+                    self._llvm_path,
+                    *args,
+                    "-S",
+                    "-o",
+                    self._llvm_path,
+                ],
+                timeout=30,
+            )
+        else:
+            run_command(
+                [
+                    self._opt,
+                    *args,
+                    self._llvm_path,
+                    "-S",
+                    "-o",
+                    self._llvm_path,
+                ],
+                timeout=30,
+            )
+
+        # compare the IR files to check if the action had an effect
+        try:
+            subprocess.check_call(
+                [self._llvm_diff, self._llvm_before_path, self._llvm_path],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=60,
+            )
+            action_had_no_effect = True
+        except subprocess.CalledProcessError:
+            action_had_no_effect = False
+
+        end_of_session = False  # TODO: this needs investigation: for how long can we apply loop unrolling? e.g., detect if there are no more loops in the IR?
+        new_action_space = None
+        return (end_of_session, new_action_space, action_had_no_effect)
+
+    @property
+    def ir(self) -> str:
+        with open(self._llvm_path) as f:
+            return f.read()
+
+    def get_observation(self, observation_space: ObservationSpace) -> Observation:
+        logging.info("Computing observation from space %s",
+                     observation_space.name)
+        if observation_space.name == "ir":
+            return Observation(string_value=self.ir)
+        elif observation_space.name == "features":
+            stats = utils.extract_statistics_from_ir(self.ir)
+            observation = Observation()
+            observation.int64_list.value[:] = list(stats.values())
+            return observation
+        elif observation_space.name == "runtime":
+            # compile LLVM to object file
+            run_command(
+                [
+                    self._llc,
+                    "-filetype=obj",
+                    self._llvm_path,
+                    "-o",
+                    self._obj_path,
+                ],
+                timeout=30,
+            )
+
+            # build object file to binary
+            run_command(
+                [
+                    "clang",
+                    self._obj_path,
+                    "-O3",
+                    "-o",
+                    self._exe_path,
+                ],
+                timeout=30,
+            )
+
+            # TODO: add documentation that benchmarks need print out execution time
+            # Running 5 times and taking the average of middle 3
+            exec_times = []
+            for _ in range(5):
+                stdout = run_command(
+                    [self._exe_path],
+                    timeout=30,
+                )
+                try:
+                    exec_times.append(int(stdout))
+                except ValueError:
+                    raise ValueError(
+                        f"Error in parsing execution time from output of command\n"
+                        f"Please ensure that the source code of the benchmark measures execution time and prints to stdout\n"
+                        f"Stdout of the program: {stdout}"
+                    )
+            exec_times = np.sort(exec_times)
+            avg_exec_time = np.mean(exec_times[1:4])
+            return Observation(scalar_double=avg_exec_time)
+        elif observation_space.name == "size":
+            # compile LLVM to object file
+            run_command(
+                [
+                    self._llc,
+                    "-filetype=obj",
+                    self._llvm_path,
+                    "-o",
+                    self._obj_path,
+                ],
+                timeout=30,
+            )
+
+            # build object file to binary
+            run_command(
+                [
+                    "clang",
+                    self._obj_path,
+                    "-Oz",
+                    "-o",
+                    self._exe_path,
+                ],
+                timeout=30,
+            )
+            binary_size = os.path.getsize(self._exe_path)
+            return Observation(scalar_double=binary_size)
+        else:
+            raise KeyError(observation_space.name)
+
+
+if __name__ == "__main__":
+    create_and_run_compiler_gym_service(UnrollingCompilationSession)

--- a/example_unrolling_service/service_py/utils.py
+++ b/example_unrolling_service/service_py/utils.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def extract_statistics_from_ir(ir: str):
+    stats = {"control_flow": 0, "arithmetic": 0, "memory": 0}
+    for line in ir.splitlines():
+        tokens = line.split()
+        if len(tokens) > 0:
+            opcode = tokens[0]
+            if opcode in [
+                "br",
+                "call",
+                "ret",
+                "switch",
+                "indirectbr",
+                "invoke",
+                "callbr",
+                "resume",
+                "catchswitch",
+                "catchret",
+                "cleanupret",
+                "unreachable",
+            ]:
+                stats["control_flow"] += 1
+            elif opcode in [
+                "fneg",
+                "add",
+                "fadd",
+                "sub",
+                "fsub",
+                "mul",
+                "fmul",
+                "udiv",
+                "sdiv",
+                "fdiv",
+                "urem",
+                "srem",
+                "frem",
+                "shl",
+                "lshr",
+                "ashr",
+                "and",
+                "or",
+                "xor",
+            ]:
+                stats["arithmetic"] += 1
+            elif opcode in [
+                "alloca",
+                "load",
+                "store",
+                "fence",
+                "cmpxchg",
+                "atomicrmw",
+                "getelementptr",
+            ]:
+                stats["memory"] += 1
+
+    return stats

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+compiler_gym

--- a/third_party/neuro-vectorizer/header.h
+++ b/third_party/neuro-vectorizer/header.h
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2019, Ameer Haj Ali (UC Berkeley), and Intel Corporation
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+/**
+ * Warmup and then measure.
+ *
+ * Adapted from Neurovectorizer's implementation:
+ * https://github.com/intel/neuro-vectorizer/blob/d1b068998c08865c59f1586845bb947229f70a51/training_data/header.h
+ *
+ * Which was in turn adapted from LLVM:
+ * https://github.com/llvm/llvm-test-suite/blob/7eca159e29ca4308256ef6e35560a2d884ac6b01/SingleSource/UnitTests/Vectorizer/gcc-loops.cpp#L330-L336
+ */
+#define BENCH(NAME, RUN_LINE, ITER, DIGEST_LINE)                               \
+  {                                                                            \
+    struct timeval Start, End;                                                 \
+    RUN_LINE;                                                                  \
+    gettimeofday(&Start, 0);                                                   \
+    for (int i = 0; i < (ITER); ++i)                                           \
+      RUN_LINE;                                                                \
+    gettimeofday(&End, 0);                                                     \
+    unsigned r = DIGEST_LINE;                                                  \
+    long mtime, s, us;                                                         \
+    s = End.tv_sec - Start.tv_sec;                                             \
+    us = End.tv_usec - Start.tv_usec;                                          \
+    mtime = (s * 1000 + us / 1000.0) + 0.5;                                    \
+    printf("%ld", mtime);                                                      \
+  }


### PR DESCRIPTION
Tried to copy and paste the `example_loop_unrolling` from the CompilerGym repo to a standalone repo, and get it to by just following 2 steps:
1. `pip install compiler_gym`
2. `python example_unrolling_service/example_without_bazel.py`

Here are some caveats/discussions:
- Maybe we should move this examples repo to `facebookresearch` GitHub account?
- Had to modify the code (see all the lines with `FIXME`) from the top-of-trunk in CompilerGym `development` branch to instead be compatible with the latest release of CompilerGym uploaded to PyPi
- To run clang commands, `llvm.clang_path()` didn't work so had to just use `"clang"` for now. But maybe that's OK as we expect people to use their own clang?
- As of now, when running the example, I am getting this error:
```
Traceback (most recent call last):
  File "example_unrolling_service/example_without_bazel.py", line 162, in <module>
    with compiler_gym.make(
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/compiler_gym/util/registration.py", line 16, in make
    return gym.make(id, **kwargs)
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/gym/envs/registration.py", line 200, in make
    return registry.make(id, **kwargs)
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/gym/envs/registration.py", line 105, in make
    env = spec.make(**kwargs)
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/gym/envs/registration.py", line 75, in make
    env = cls(**_kwargs)
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/compiler_gym/envs/compiler_env.py", line 287, in __init__
    self.benchmark = benchmark or next(self.datasets.benchmarks())
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/compiler_gym/envs/compiler_env.py", line 460, in benchmark
    benchmark_object = self.datasets.benchmark(benchmark)
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/compiler_gym/datasets/datasets.py", line 270, in benchmark
    return self.benchmark_from_parsed_uri(BenchmarkUri.from_string(uri))
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/compiler_gym/datasets/datasets.py", line 303, in benchmark_from_parsed_uri
    return dataset.benchmark_from_parsed_uri(uri)
  File "/Users/melhoushi/opt/anaconda3/envs/compiler_gym_examples/lib/python3.8/site-packages/compiler_gym/datasets/dataset.py", line 427, in benchmark_from_parsed_uri
    raise NotImplementedError("abstract class")
NotImplementedError: abstract class
```

Closes !https://github.com/facebookresearch/CompilerGym/issues/532
